### PR TITLE
Hexadecimal constants when using bitwise operators

### DIFF
--- a/src/org/jetbrains/java/decompiler/main/collectors/VarNamesCollector.java
+++ b/src/org/jetbrains/java/decompiler/main/collectors/VarNamesCollector.java
@@ -83,9 +83,8 @@ public class VarNamesCollector {
 					name = name.substring(name.lastIndexOf('/') + 1);
 				}
 			}
-			return getFreeName_(varType.arrayDim > 0 ? arrayname : name);
 		}
-		return getFreeName(varType.arrayDim > 0 ? arrayname : (name + "_" + index));
+		return getFreeName((varType.arrayDim > 0 ? arrayname : name) + "_" + index);
 	}
 
 }

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
@@ -15,6 +15,10 @@
  */
 package org.jetbrains.java.decompiler.modules.decompiler.exps;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
 import org.jetbrains.java.decompiler.code.CodeConstants;
 import org.jetbrains.java.decompiler.main.ClassesProcessor.ClassNode;
 import org.jetbrains.java.decompiler.main.DecompilerContext;
@@ -25,10 +29,6 @@ import org.jetbrains.java.decompiler.modules.decompiler.vars.CheckTypesResult;
 import org.jetbrains.java.decompiler.struct.StructField;
 import org.jetbrains.java.decompiler.struct.gen.VarType;
 import org.jetbrains.java.decompiler.util.InterpreterUtil;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
 
 public class AssignmentExprent extends Exprent {
 
@@ -135,7 +135,7 @@ public class AssignmentExprent extends Exprent {
 			buffer.append(left.toJava(indent, tracer));
 		}
 
-		TextBuffer res = right.toJava(indent, tracer);
+		TextBuffer res = right.toJava(indent, tracer, condType >= 4 && condType <= 6);
 
 		if (condType == CONDITION_NONE &&
 				!leftType.isSuperset(rightType) &&

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
@@ -15,6 +15,13 @@
  */
 package org.jetbrains.java.decompiler.modules.decompiler.exps;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+
 import org.jetbrains.java.decompiler.main.DecompilerContext;
 import org.jetbrains.java.decompiler.main.TextBuffer;
 import org.jetbrains.java.decompiler.main.collectors.BytecodeMappingTracer;
@@ -26,9 +33,6 @@ import org.jetbrains.java.decompiler.struct.match.IMatchable;
 import org.jetbrains.java.decompiler.struct.match.MatchEngine;
 import org.jetbrains.java.decompiler.struct.match.MatchNode;
 import org.jetbrains.java.decompiler.struct.match.MatchNode.RuleValue;
-
-import java.util.*;
-import java.util.Map.Entry;
 
 public class Exprent implements IMatchable {
 
@@ -122,6 +126,10 @@ public class Exprent implements IMatchable {
 
 	public TextBuffer toJava(int indent, BytecodeMappingTracer tracer) {
 		throw new RuntimeException("not implemented");
+	}
+
+	public TextBuffer toJava(int indent, BytecodeMappingTracer tracer, boolean binaryOp) {
+		return toJava(indent, tracer);
 	}
 
 	public void replaceExprent(Exprent oldExpr, Exprent newExpr) {

--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
@@ -15,6 +15,12 @@
  */
 package org.jetbrains.java.decompiler.modules.decompiler.exps;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.jetbrains.java.decompiler.code.CodeConstants;
 import org.jetbrains.java.decompiler.main.TextBuffer;
 import org.jetbrains.java.decompiler.main.collectors.BytecodeMappingTracer;
@@ -25,8 +31,6 @@ import org.jetbrains.java.decompiler.struct.match.MatchEngine;
 import org.jetbrains.java.decompiler.struct.match.MatchNode;
 import org.jetbrains.java.decompiler.util.InterpreterUtil;
 import org.jetbrains.java.decompiler.util.ListStack;
-
-import java.util.*;
 
 public class FunctionExprent extends Exprent {
 
@@ -513,8 +517,8 @@ public class FunctionExprent extends Exprent {
 			}
 		}
 
-		TextBuffer res = expr.toJava(indent, tracer);
-
+		TextBuffer res = expr.toJava(indent, tracer, funcType >= FUNCTION_AND && funcType <= FUNCTION_XOR);
+		
 		if (parentheses) {
 			res.enclose("(", ")");
 		}


### PR DESCRIPTION
Also, fixed var naming and commented out the use of '\uxxxx' literals